### PR TITLE
CI: drop py37; add p310

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.9']
+        python: ['3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
No reason to test 3.7 anymore as buster is no longer in use and 3.10 is currently the next version so what is likely to end up in bookworm (or possibly 3.11 but that's not released).