### PR TITLE
add *.wikitide.net to CSP

### DIFF
--- a/modules/varnish/data/csp.yaml
+++ b/modules/varnish/data/csp.yaml
@@ -68,6 +68,7 @@ img-src:
   - 'data:'
   - '*.miraheze.org'
   - '*.betaheze.org'
+  - '*.wikitide.net'
   - 'upload.wikimedia.org'
   - 'wikimedia.org'
   - 'maps.google.com'


### PR DESCRIPTION
The URL was switched without this being done, resulting in breakages.